### PR TITLE
Polish macOS UI interactions

### DIFF
--- a/Sources/KumoApp/KumoApp.swift
+++ b/Sources/KumoApp/KumoApp.swift
@@ -5,11 +5,12 @@ import KumoCoreKit
 @main
 struct KumoApp: App {
     @State private var store = KumoAppStore()
+    @State private var navigation = KumoNavigationState()
     @NSApplicationDelegateAdaptor(KumoAppDelegate.self) private var appDelegate
 
     var body: some Scene {
         WindowGroup(id: "main") {
-            KumoRootView(store: store)
+            KumoRootView(store: store, navigation: navigation)
         }
         .defaultSize(width: 1040, height: 720)
         .windowResizability(.contentMinSize)
@@ -46,6 +47,14 @@ struct KumoApp: App {
 
                 Divider()
 
+                Button(store.status.systemProxyEnabled ? "Disable System Proxy" : "Enable System Proxy") {
+                    store.setSystemProxyEnabled(!store.status.systemProxyEnabled)
+                }
+                .keyboardShortcut("p", modifiers: [.command, .control])
+                .disabled(store.isLoading || (store.status.state != .running && !store.status.systemProxyEnabled))
+
+                Divider()
+
                 Button("Rule Mode") {
                     Task { await store.setMode(.rule) }
                 }
@@ -71,6 +80,23 @@ struct KumoApp: App {
                 }
                 .disabled(store.isLoading)
             }
+
+            CommandMenu("Navigate") {
+                navigationButton("Overview", destination: .overview, key: "1")
+                navigationButton("Profiles", destination: .profiles, key: "2")
+                navigationButton("Proxies", destination: .proxies, key: "3")
+
+                Divider()
+
+                navigationButton("Connections", destination: .connections, key: "4")
+                navigationButton("Logs", destination: .logs, key: "5")
+                navigationButton("Rules", destination: .rules, key: "6")
+
+                Divider()
+
+                navigationButton("Core", destination: .core, key: "7")
+                navigationButton("System Proxy", destination: .systemProxy, key: "8")
+            }
         }
 
         Settings {
@@ -87,14 +113,26 @@ struct KumoApp: App {
     }
 }
 
+private extension KumoApp {
+    func navigationButton(_ title: String, destination: SidebarDestination, key: KeyEquivalent) -> some View {
+        Button(title) {
+            navigation.selection = destination
+            KumoAppContext.shared.openMainWindow()
+        }
+        .keyboardShortcut(key, modifiers: [.command, .option])
+    }
+}
+
 private struct KumoRootView: View {
     @Environment(\.openWindow) private var openWindow
     @Environment(\.openSettings) private var openSettings
     let store: KumoAppStore
+    let navigation: KumoNavigationState
 
     var body: some View {
         ContentView()
             .environment(store)
+            .environment(navigation)
             .frame(minWidth: 820, minHeight: 560)
             .task {
                 KumoAppContext.shared.attach(store: store)

--- a/Sources/KumoApp/Views/ConfigureViews.swift
+++ b/Sources/KumoApp/Views/ConfigureViews.swift
@@ -286,6 +286,8 @@ struct CoreView: View {
 struct SystemProxyView: View {
     @Environment(KumoAppStore.self) private var store
     @State private var systemProxyDraft = SystemProxySettings()
+    @State private var bypassTextDraft = SystemProxySettings.defaultBypassList
+        .joined(separator: "\n")
 
     var body: some View {
         KumoPage(title: "System Proxy") {
@@ -328,13 +330,17 @@ struct SystemProxyView: View {
 
                 if systemProxyDraft.mode == .manual {
                     Section("Bypass") {
-                        TextEditor(text: bypassTextBinding)
+                        TextEditor(text: $bypassTextDraft)
                             .font(.system(.body, design: .monospaced))
                             .frame(minHeight: 120)
+                            .onChange(of: bypassTextDraft) { _, newValue in
+                                systemProxyDraft.bypassList = Self.bypassList(from: newValue)
+                            }
                         Button("Add Defaults") {
-                            systemProxyDraft.bypassList = Array(
-                                Set(systemProxyDraft.bypassList + SystemProxySettings.defaultBypassList)
-                            ).sorted()
+                            let bypassList = Self.bypassList(from: bypassTextDraft)
+                            updateBypassList(
+                                Array(Set(bypassList + SystemProxySettings.defaultBypassList)).sorted()
+                            )
                         }
                     }
                 }
@@ -360,7 +366,7 @@ struct SystemProxyView: View {
         }
         .onChange(of: systemProxySettings) { oldValue, newValue in
             if systemProxyDraft == oldValue {
-                systemProxyDraft = newValue
+                updateSystemProxyDraft(newValue)
             }
         }
     }
@@ -381,9 +387,7 @@ struct SystemProxyView: View {
         settings.networkService = settings.networkService.trimmingCharacters(in: .whitespacesAndNewlines)
         settings.host = settings.host.trimmingCharacters(in: .whitespacesAndNewlines)
         settings.port = max(1, min(65535, settings.port))
-        settings.bypassList = settings.bypassList
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
+        settings.bypassList = Self.bypassList(from: bypassTextDraft)
         return settings
     }
 
@@ -419,24 +423,33 @@ struct SystemProxyView: View {
         }
     }
 
-    private var bypassTextBinding: Binding<String> {
-        Binding {
-            systemProxyDraft.bypassList.joined(separator: "\n")
-        } set: { value in
-            systemProxyDraft.bypassList = value
-                .split(separator: "\n")
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { !$0.isEmpty }
-        }
+    private static func bypassText(from bypassList: [String]) -> String {
+        bypassList.joined(separator: "\n")
+    }
+
+    private static func bypassList(from text: String) -> [String] {
+        text.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
     }
 
     private func resetSystemProxyDraft() {
-        systemProxyDraft = systemProxySettings
+        updateSystemProxyDraft(systemProxySettings)
+    }
+
+    private func updateSystemProxyDraft(_ settings: SystemProxySettings) {
+        systemProxyDraft = settings
+        bypassTextDraft = Self.bypassText(from: settings.bypassList)
+    }
+
+    private func updateBypassList(_ bypassList: [String]) {
+        systemProxyDraft.bypassList = bypassList
+        bypassTextDraft = Self.bypassText(from: bypassList)
     }
 
     private func applySystemProxyDraft() {
         let settings = normalizedSystemProxyDraft
-        systemProxyDraft = settings
+        updateSystemProxyDraft(settings)
         store.updateSystemProxySettings(settings)
     }
 }

--- a/Sources/KumoApp/Views/ConfigureViews.swift
+++ b/Sources/KumoApp/Views/ConfigureViews.swift
@@ -86,6 +86,7 @@ private struct DebouncedTextEditor: View {
 struct CoreView: View {
     @Environment(KumoAppStore.self) private var store
     @State private var isChoosingCore = false
+    @State private var runtimeDraft = CoreRuntimeSettings()
 
     var body: some View {
         KumoPage(title: "Core") {
@@ -99,7 +100,7 @@ struct CoreView: View {
                     LabeledContent("Log Level", value: store.coreConfiguration.logLevel)
                 }
 
-                Section("Runtime Settings") {
+                Section {
                     TextField("Mixed Port", value: mixedPortBinding, format: .number)
                     Picker("Log Level", selection: logLevelBinding) {
                         Text("Silent").tag("silent")
@@ -114,6 +115,24 @@ struct CoreView: View {
                         currentSecret: store.status.endpoint.secret,
                         commit: { store.setControllerSecret($0) }
                     )
+                    HStack {
+                        Spacer()
+                        Button("Reset") {
+                            resetRuntimeDraft()
+                        }
+                        .disabled(!hasRuntimeDraftChanges || store.isLoading)
+
+                        Button("Apply") {
+                            applyRuntimeDraft()
+                        }
+                        .disabled(!hasRuntimeDraftChanges || store.isLoading)
+                    }
+                } header: {
+                    Text("Runtime Settings")
+                } footer: {
+                    Text("Changes are staged locally until you apply them. Kumo-owned runtime keys are written through the shared controller layer.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 Section("Core Binary") {
@@ -165,6 +184,12 @@ struct CoreView: View {
         .task {
             store.refreshCoreCandidates()
             await store.loadCoreConfiguration()
+            resetRuntimeDraft()
+        }
+        .onChange(of: runtimeSettings) { oldValue, newValue in
+            if runtimeDraft == oldValue {
+                runtimeDraft = newValue
+            }
         }
     }
 
@@ -184,44 +209,56 @@ struct CoreView: View {
         store.status.runtimeSettings ?? CoreRuntimeSettings(mixedPort: store.status.proxyPorts.mixedPort)
     }
 
+    private var hasRuntimeDraftChanges: Bool {
+        normalizedRuntimeDraft != runtimeSettings
+    }
+
+    private var normalizedRuntimeDraft: CoreRuntimeSettings {
+        var settings = runtimeDraft
+        settings.mixedPort = max(1, min(65535, settings.mixedPort))
+        return settings
+    }
+
     private var mixedPortBinding: Binding<Int> {
         Binding {
-            runtimeSettings.mixedPort
+            runtimeDraft.mixedPort
         } set: { value in
-            var settings = runtimeSettings
-            settings.mixedPort = max(1, min(65535, value))
-            Task { await store.updateRuntimeSettings(settings) }
+            runtimeDraft.mixedPort = max(1, min(65535, value))
         }
     }
 
     private var logLevelBinding: Binding<String> {
         Binding {
-            runtimeSettings.logLevel
+            runtimeDraft.logLevel
         } set: { value in
-            var settings = runtimeSettings
-            settings.logLevel = value
-            Task { await store.updateRuntimeSettings(settings) }
+            runtimeDraft.logLevel = value
         }
     }
 
     private var allowLANBinding: Binding<Bool> {
         Binding {
-            runtimeSettings.allowLAN
+            runtimeDraft.allowLAN
         } set: { value in
-            var settings = runtimeSettings
-            settings.allowLAN = value
-            Task { await store.updateRuntimeSettings(settings) }
+            runtimeDraft.allowLAN = value
         }
     }
 
     private var ipv6Binding: Binding<Bool> {
         Binding {
-            runtimeSettings.ipv6
+            runtimeDraft.ipv6
         } set: { value in
-            var settings = runtimeSettings
-            settings.ipv6 = value
-            Task { await store.updateRuntimeSettings(settings) }
+            runtimeDraft.ipv6 = value
         }
+    }
+
+    private func resetRuntimeDraft() {
+        runtimeDraft = runtimeSettings
+    }
+
+    private func applyRuntimeDraft() {
+        let settings = normalizedRuntimeDraft
+        runtimeDraft = settings
+        Task { await store.updateRuntimeSettings(settings) }
     }
 
     private var installCoreButton: some View {
@@ -248,7 +285,7 @@ struct CoreView: View {
 
 struct SystemProxyView: View {
     @Environment(KumoAppStore.self) private var store
-    @State private var bypassText = ""
+    @State private var systemProxyDraft = SystemProxySettings()
 
     var body: some View {
         KumoPage(title: "System Proxy") {
@@ -270,35 +307,43 @@ struct SystemProxyView: View {
                     Text("System Proxy updates macOS proxy settings through networksetup. It does not add a VPN configuration; helper installation uses the administrator authorization prompt.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                    HStack {
+                        Spacer()
+                        Button("Reset") {
+                            resetSystemProxyDraft()
+                        }
+                        .disabled(!hasSystemProxyDraftChanges)
+
+                        Button("Apply") {
+                            applySystemProxyDraft()
+                        }
+                        .disabled(!hasSystemProxyDraftChanges)
+                    }
+                } footer: {
+                    Text("Network service, host, port, mode, bypass, and PAC script changes are staged until you apply them.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
-                if systemProxySettings.mode == .manual {
+                if systemProxyDraft.mode == .manual {
                     Section("Bypass") {
-                        DebouncedTextEditor(value: bypassText) { newValue in
-                            bypassText = newValue
-                            var settings = systemProxySettings
-                            settings.bypassList = newValue
-                                .split(separator: "\n")
-                                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                                .filter { !$0.isEmpty }
-                            store.updateSystemProxySettings(settings)
-                        }
+                        TextEditor(text: bypassTextBinding)
+                            .font(.system(.body, design: .monospaced))
+                            .frame(minHeight: 120)
                         Button("Add Defaults") {
-                            var settings = systemProxySettings
-                            settings.bypassList = Array(Set(settings.bypassList + SystemProxySettings.defaultBypassList)).sorted()
-                            bypassText = settings.bypassList.joined(separator: "\n")
-                            store.updateSystemProxySettings(settings)
+                            systemProxyDraft.bypassList = Array(
+                                Set(systemProxyDraft.bypassList + SystemProxySettings.defaultBypassList)
+                            ).sorted()
                         }
                     }
                 }
 
-                if systemProxySettings.mode == .pac {
+                if systemProxyDraft.mode == .pac {
                     Section {
-                        DebouncedTextEditor(value: systemProxySettings.pacScript, minHeight: 200) { newValue in
-                            var settings = systemProxySettings
-                            settings.pacScript = newValue
-                            store.updateSystemProxySettings(settings)
-                        }
+                        TextEditor(text: $systemProxyDraft.pacScript)
+                            .font(.system(.body, design: .monospaced))
+                            .frame(minHeight: 200)
                     } header: {
                         Text("PAC Script")
                     } footer: {
@@ -311,7 +356,12 @@ struct SystemProxyView: View {
             .formStyle(.grouped)
         }
         .task {
-            bypassText = systemProxySettings.bypassList.joined(separator: "\n")
+            resetSystemProxyDraft()
+        }
+        .onChange(of: systemProxySettings) { oldValue, newValue in
+            if systemProxyDraft == oldValue {
+                systemProxyDraft = newValue
+            }
         }
     }
 
@@ -322,44 +372,72 @@ struct SystemProxyView: View {
         )
     }
 
+    private var hasSystemProxyDraftChanges: Bool {
+        normalizedSystemProxyDraft != systemProxySettings
+    }
+
+    private var normalizedSystemProxyDraft: SystemProxySettings {
+        var settings = systemProxyDraft
+        settings.networkService = settings.networkService.trimmingCharacters(in: .whitespacesAndNewlines)
+        settings.host = settings.host.trimmingCharacters(in: .whitespacesAndNewlines)
+        settings.port = max(1, min(65535, settings.port))
+        settings.bypassList = settings.bypassList
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return settings
+    }
+
     private var networkServiceBinding: Binding<String> {
         Binding {
-            systemProxySettings.networkService
+            systemProxyDraft.networkService
         } set: { value in
-            var settings = systemProxySettings
-            settings.networkService = value
-            store.updateSystemProxySettings(settings)
+            systemProxyDraft.networkService = value
         }
     }
 
     private var hostBinding: Binding<String> {
         Binding {
-            systemProxySettings.host
+            systemProxyDraft.host
         } set: { value in
-            var settings = systemProxySettings
-            settings.host = value
-            store.updateSystemProxySettings(settings)
+            systemProxyDraft.host = value
         }
     }
 
     private var portBinding: Binding<Int> {
         Binding {
-            systemProxySettings.port
+            systemProxyDraft.port
         } set: { value in
-            var settings = systemProxySettings
-            settings.port = value
-            store.updateSystemProxySettings(settings)
+            systemProxyDraft.port = max(1, min(65535, value))
         }
     }
 
     private var modeBinding: Binding<SystemProxyMode> {
         Binding {
-            systemProxySettings.mode
+            systemProxyDraft.mode
         } set: { value in
-            var settings = systemProxySettings
-            settings.mode = value
-            store.updateSystemProxySettings(settings)
+            systemProxyDraft.mode = value
         }
+    }
+
+    private var bypassTextBinding: Binding<String> {
+        Binding {
+            systemProxyDraft.bypassList.joined(separator: "\n")
+        } set: { value in
+            systemProxyDraft.bypassList = value
+                .split(separator: "\n")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+        }
+    }
+
+    private func resetSystemProxyDraft() {
+        systemProxyDraft = systemProxySettings
+    }
+
+    private func applySystemProxyDraft() {
+        let settings = normalizedSystemProxyDraft
+        systemProxyDraft = settings
+        store.updateSystemProxySettings(settings)
     }
 }
 
@@ -379,6 +457,7 @@ struct DNSView: View {
 
 struct TunView: View {
     @Environment(KumoAppStore.self) private var store
+    @State private var isConfirmingServiceUninstall = false
     let onNavigate: (SidebarDestination) -> Void
 
     var body: some View {
@@ -399,7 +478,7 @@ struct TunView: View {
                         .disabled(store.isLoading)
                         .help("Install or repair Kumo Helper with macOS administrator authorization.")
                         Button("Uninstall Service") {
-                            Task { await store.uninstallServiceMode() }
+                            isConfirmingServiceUninstall = true
                         }
                         .disabled(!store.serviceModeStatus.isInstalled || store.isLoading)
                     }
@@ -452,6 +531,18 @@ struct TunView: View {
         .task {
             store.refreshServiceModeStatus()
             store.refreshTunStatus()
+        }
+        .confirmationDialog(
+            "Uninstall Kumo Helper?",
+            isPresented: $isConfirmingServiceUninstall,
+            titleVisibility: .visible
+        ) {
+            Button("Uninstall Service", role: .destructive) {
+                Task { await store.uninstallServiceMode() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the privileged helper used for TUN and protected system integration. TUN will not be manageable until the service is installed again.")
         }
     }
 
@@ -632,32 +723,7 @@ struct OverridesView: View {
     var body: some View {
         KumoPage(title: "Overrides") {
             VStack(alignment: .leading, spacing: 12) {
-                HStack(spacing: 8) {
-                    TextField("Remote override URL", text: $remoteURL)
-                        .textFieldStyle(.roundedBorder)
-                    Picker("Format", selection: $format) {
-                        Text("YAML").tag(OverrideFormat.yaml)
-                        Text("JavaScript").tag(OverrideFormat.javascript)
-                    }
-                    .frame(width: 140)
-                    Toggle("Global", isOn: $isGlobal)
-                        .toggleStyle(.checkbox)
-                    Button("Import URL") {
-                        Task {
-                            await store.addRemoteOverride(urlString: remoteURL, format: format, isGlobal: isGlobal)
-                            if store.errorMessage == nil {
-                                remoteURL = ""
-                            }
-                        }
-                    }
-                    .disabled(remoteURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || store.isLoading)
-                    Button("Import File…") {
-                        isImportingFile = true
-                    }
-                    Button("New…") {
-                        newDraft = NewOverrideDraft(isGlobal: isGlobal)
-                    }
-                }
+                importControls
 
                 if store.overrides.isEmpty {
                     KumoEmptyState(
@@ -746,6 +812,66 @@ struct OverridesView: View {
             }
         } message: { _ in
             Text("This removes the local override file and metadata.")
+        }
+    }
+
+    private var importControls: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                remoteOverrideURLField
+                overrideOptions
+                overrideActionGroup
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                remoteOverrideURLField
+                HStack(spacing: 8) {
+                    overrideOptions
+                    Spacer()
+                    overrideActionGroup
+                }
+            }
+        }
+    }
+
+    private var remoteOverrideURLField: some View {
+        TextField("Remote override URL", text: $remoteURL)
+            .textFieldStyle(.roundedBorder)
+    }
+
+    private var overrideOptions: some View {
+        HStack(spacing: 8) {
+            Picker("Format", selection: $format) {
+                Text("YAML").tag(OverrideFormat.yaml)
+                Text("JavaScript").tag(OverrideFormat.javascript)
+            }
+            .frame(width: 140)
+
+            Toggle("Global", isOn: $isGlobal)
+                .toggleStyle(.checkbox)
+                .fixedSize()
+        }
+    }
+
+    private var overrideActionGroup: some View {
+        HStack(spacing: 8) {
+            Button("Import URL") {
+                Task {
+                    await store.addRemoteOverride(urlString: remoteURL, format: format, isGlobal: isGlobal)
+                    if store.errorMessage == nil {
+                        remoteURL = ""
+                    }
+                }
+            }
+            .disabled(remoteURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || store.isLoading)
+
+            Button("Import File…") {
+                isImportingFile = true
+            }
+
+            Button("New…") {
+                newDraft = NewOverrideDraft(isGlobal: isGlobal)
+            }
         }
     }
 

--- a/Sources/KumoApp/Views/ContentView.swift
+++ b/Sources/KumoApp/Views/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Observation
 import KumoCoreKit
 
 enum SidebarDestination: String, CaseIterable, Identifiable {
@@ -45,9 +46,15 @@ struct SidebarSection: Identifiable {
     let destinations: [SidebarDestination]
 }
 
+@MainActor
+@Observable
+final class KumoNavigationState {
+    var selection: SidebarDestination = .overview
+}
+
 struct ContentView: View {
     @Environment(KumoAppStore.self) private var store
-    @State private var selection: SidebarDestination = .overview
+    @Environment(KumoNavigationState.self) private var navigation
     private let sections = [
         SidebarSection(id: "daily", title: "Daily", destinations: [.overview, .profiles, .proxies]),
         SidebarSection(id: "inspect", title: "Inspect", destinations: [.connections, .logs, .rules]),
@@ -101,7 +108,7 @@ struct ContentView: View {
                 if isCoreNotFoundError {
                     Button("Open Core Settings") {
                         store.clearError()
-                        selection = .core
+                        navigation.selection = .core
                     }
 
                     Button("Scan Again") {
@@ -127,7 +134,7 @@ struct ContentView: View {
         } detail: {
             detailView
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .navigationTitle(selection.rawValue)
+                .navigationTitle(navigation.selection.rawValue)
         }
         .navigationDestination(for: SidebarDestination.self) { destination in
             detailView(for: destination)
@@ -136,7 +143,7 @@ struct ContentView: View {
     }
 
     private var sidebarList: some View {
-        List(selection: $selection) {
+        List(selection: selectionBinding) {
             ForEach(sections) { section in
                 Section(section.title) {
                     ForEach(section.destinations) { destination in
@@ -187,7 +194,7 @@ struct ContentView: View {
 
     @ViewBuilder
     private var detailView: some View {
-        detailView(for: selection)
+        detailView(for: navigation.selection)
     }
 
     @ViewBuilder
@@ -225,7 +232,17 @@ struct ContentView: View {
     }
 
     private var navigateAction: (SidebarDestination) -> Void {
-        { destination in selection = destination }
+        { destination in navigation.selection = destination }
+    }
+
+    private var selectionBinding: Binding<SidebarDestination?> {
+        Binding {
+            navigation.selection
+        } set: { destination in
+            if let destination {
+                navigation.selection = destination
+            }
+        }
     }
 
 }

--- a/Sources/KumoApp/Views/InspectViews.swift
+++ b/Sources/KumoApp/Views/InspectViews.swift
@@ -39,7 +39,6 @@ struct ConnectionsView: View {
                         Text(connection.download.kumoByteCount)
                     }
                 }
-                .searchable(text: $searchText, placement: .toolbar, prompt: "Search connections")
                 .contextMenu(forSelectionType: ConnectionEntry.ID.self) { selection in
                     Button("Copy Host") {
                         copy(\.host, for: selection)
@@ -56,30 +55,31 @@ struct ConnectionsView: View {
                     }
                     .disabled(selection.isEmpty || store.status.state != .running)
                 }
-                .toolbar {
-                    ToolbarItem(placement: .secondaryAction) {
-                        Button(role: .destructive) {
-                            isConfirmingCloseAll = true
-                        } label: {
-                            Label("Close All", systemImage: "xmark.circle")
-                        }
-                        .disabled(store.connections.isEmpty || store.status.state != .running)
-                        .help("Close every active connection")
-                    }
-                }
-                .confirmationDialog(
-                    "Close all \(store.connections.count) connections?",
-                    isPresented: $isConfirmingCloseAll,
-                    titleVisibility: .visible
-                ) {
-                    Button("Close All", role: .destructive) {
-                        Task { await store.closeAllConnections() }
-                    }
-                    Button("Cancel", role: .cancel) {}
-                } message: {
-                    Text("Active TCP/UDP sessions tracked by Mihomo will be terminated. Apps may need to reconnect.")
-                }
             }
+        }
+        .searchable(text: $searchText, placement: .toolbar, prompt: "Search connections")
+        .toolbar {
+            ToolbarItem(placement: .secondaryAction) {
+                Button(role: .destructive) {
+                    isConfirmingCloseAll = true
+                } label: {
+                    Label("Close All", systemImage: "xmark.circle")
+                }
+                .disabled(store.connections.isEmpty || store.status.state != .running)
+                .help("Close every active connection")
+            }
+        }
+        .confirmationDialog(
+            "Close all \(store.connections.count) connections?",
+            isPresented: $isConfirmingCloseAll,
+            titleVisibility: .visible
+        ) {
+            Button("Close All", role: .destructive) {
+                Task { await store.closeAllConnections() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Active TCP/UDP sessions tracked by Mihomo will be terminated. Apps may need to reconnect.")
         }
         .task {
             await store.loadInspectData()
@@ -177,6 +177,7 @@ enum LogLevelFilter: String, CaseIterable, Identifiable {
 
 struct LogsView: View {
     @Environment(KumoAppStore.self) private var store
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var searchText = ""
     @State private var level: LogLevelFilter = .all
     @State private var followsLiveLogs = false
@@ -208,11 +209,11 @@ struct LogsView: View {
                                 }
                             }
                     }
-                    .searchable(text: $searchText, placement: .toolbar, prompt: "Search logs")
                     .scrollEdgeEffectStyleIfAvailable()
                 }
             }
         }
+        .searchable(text: $searchText, placement: .toolbar, prompt: "Search logs")
         .task {
             await store.loadInspectData()
         }
@@ -245,7 +246,7 @@ struct LogsView: View {
                         Circle()
                             .fill(Color.red)
                             .frame(width: 6, height: 6)
-                            .symbolEffect(.pulse, isActive: followsLiveLogs)
+                            .symbolEffect(.pulse, isActive: followsLiveLogs && !reduceMotion)
                     }
                     Text(followsLiveLogs ? "Pause" : "Follow")
                 }
@@ -367,10 +368,10 @@ struct RulesView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-                .searchable(text: $searchText, placement: .toolbar, prompt: "Search rules")
                 .scrollEdgeEffectStyleIfAvailable()
             }
         }
+        .searchable(text: $searchText, placement: .toolbar, prompt: "Search rules")
         .task {
             await store.loadInspectData()
         }
@@ -418,6 +419,7 @@ private struct HitRateBadge: View {
                 .kumoSubtleBackground(in: .capsule)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("Show rule statistics")
         .popover(isPresented: $showPopover, arrowEdge: .top) {
             VStack(alignment: .leading, spacing: 6) {
                 LabeledContent("Hit", value: "\(rule.hitCount)")

--- a/Sources/KumoApp/Views/OverviewView.swift
+++ b/Sources/KumoApp/Views/OverviewView.swift
@@ -75,7 +75,7 @@ struct OverviewView: View {
                         Divider()
                             .padding(.leading, 34)
                     }
-                    ProxyGroupStatusRow(group: group)
+                    ProxyGroupStatusRow(group: group, onNavigate: onNavigate)
                 }
             }
         }
@@ -376,6 +376,8 @@ private struct NetworkMetricCard: View {
 private struct ProxyGroupStatusRow: View {
     @Environment(KumoAppStore.self) private var store
     let group: ProxyGroup
+    let onNavigate: (SidebarDestination) -> Void
+    private let maxMenuProxyCount = 12
 
     var body: some View {
         HStack(spacing: 12) {
@@ -413,7 +415,7 @@ private struct ProxyGroupStatusRow: View {
 
                 Divider()
 
-                ForEach(group.proxies) { proxy in
+                ForEach(Array(group.proxies.prefix(maxMenuProxyCount))) { proxy in
                     Button {
                         Task { await store.selectProxy(group: group, proxy: proxy) }
                     } label: {
@@ -423,6 +425,13 @@ private struct ProxyGroupStatusRow: View {
                         )
                     }
                     .disabled(group.selectedProxyName == proxy.name || store.isLoading)
+                }
+
+                if group.proxies.count > maxMenuProxyCount {
+                    Divider()
+                    Button("Open Proxies…") {
+                        onNavigate(.proxies)
+                    }
                 }
             }
         } label: {

--- a/Sources/KumoApp/Views/ProfilesView.swift
+++ b/Sources/KumoApp/Views/ProfilesView.swift
@@ -14,32 +14,7 @@ struct ProfilesView: View {
     var body: some View {
         KumoPage(title: "Profiles") {
             VStack(alignment: .leading, spacing: 14) {
-                HStack(spacing: 8) {
-                    TextField("Subscription URL", text: $remoteURL)
-                        .textFieldStyle(.roundedBorder)
-                        .focused($urlFieldFocused)
-                        .onSubmit { importRemoteProfile() }
-
-                    PasteButton(payloadType: String.self) { values in
-                        if let value = values.first {
-                            remoteURL = value.trimmingCharacters(in: .whitespacesAndNewlines)
-                        }
-                    }
-                    .labelStyle(.iconOnly)
-                    .help("Paste subscription URL")
-
-                    Toggle("Use Kumo to fetch", isOn: $usesProxyForImport)
-                        .toggleStyle(.checkbox)
-
-                    Button("Import URL") {
-                        importRemoteProfile()
-                    }
-                    .disabled(remoteURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || store.isImportingProfile)
-
-                    Button("Import File…") {
-                        isImportingFile = true
-                    }
-                }
+                importControls
 
                 if store.profiles.isEmpty {
                     KumoEmptyState(
@@ -130,6 +105,60 @@ struct ProfilesView: View {
         }
     }
 
+    private var importControls: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                subscriptionURLField
+                proxyImportToggle
+                importActionGroup
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                subscriptionURLField
+                HStack(spacing: 8) {
+                    proxyImportToggle
+                    Spacer()
+                    importActionGroup
+                }
+            }
+        }
+    }
+
+    private var subscriptionURLField: some View {
+        TextField("Subscription URL", text: $remoteURL)
+            .textFieldStyle(.roundedBorder)
+            .focused($urlFieldFocused)
+            .onSubmit { importRemoteProfile() }
+    }
+
+    private var proxyImportToggle: some View {
+        Toggle("Use Kumo to fetch", isOn: $usesProxyForImport)
+            .toggleStyle(.checkbox)
+            .fixedSize()
+    }
+
+    private var importActionGroup: some View {
+        HStack(spacing: 8) {
+            PasteButton(payloadType: String.self) { values in
+                if let value = values.first {
+                    remoteURL = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            }
+            .labelStyle(.iconOnly)
+            .help("Paste subscription URL")
+            .accessibilityLabel("Paste subscription URL")
+
+            Button("Import URL") {
+                importRemoteProfile()
+            }
+            .disabled(remoteURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || store.isImportingProfile)
+
+            Button("Import File…") {
+                isImportingFile = true
+            }
+        }
+    }
+
     private func importRemoteProfile() {
         let value = remoteURL.trimmingCharacters(in: .whitespacesAndNewlines)
         Task {
@@ -162,7 +191,6 @@ private struct ProfileRow: View {
     let profile: ProfileSummary
     let onEdit: () -> Void
     let onDelete: () -> Void
-    @State private var isHovered = false
 
     var body: some View {
         HStack(spacing: 12) {
@@ -196,12 +224,11 @@ private struct ProfileRow: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            if !profile.isCurrent && isHovered {
+            if !profile.isCurrent {
                 Button("Use") {
                     Task { await store.selectProfile(profile) }
                 }
                 .disabled(store.isLoading)
-                .transition(.opacity)
             }
             Menu {
                 Button("Edit") {
@@ -222,8 +249,6 @@ private struct ProfileRow: View {
             .buttonStyle(.borderless)
         }
         .padding(.vertical, 4)
-        .onHover { isHovered = $0 }
-        .animation(.snappy(duration: 0.15), value: isHovered)
         .contextMenu {
             Button("Use Profile") {
                 Task { await store.selectProfile(profile) }

--- a/docs/interfaces/macos-swiftui-interface.md
+++ b/docs/interfaces/macos-swiftui-interface.md
@@ -14,6 +14,8 @@ The app uses:
 - `KumoStatusItemController` for the persistent menu bar icon and native quick menu. It uses `NSStatusItem` so Kumo can rebuild menu content dynamically and avoid SwiftUI `MenuBarExtra` visibility limitations.
 - `CommandMenu("Control")` for keyboard-accessible Kumo commands.
 - `CommandGroup(after: .toolbar)` to expose `Toggle Sidebar` (Cmd+Ctrl+S).
+- `CommandMenu("Navigate")` for keyboard-accessible jumps to the primary Daily
+  and Inspect destinations without moving navigation state into `KumoCoreKit`.
 - `@NSApplicationDelegateAdaptor(KumoAppDelegate.self)` to bridge AppKit-only behaviour (status item setup, Services menu, Spotlight handoff, Dock badge timer, `SMAppService.mainApp` synchronisation, `applicationShouldTerminateAfterLastWindowClosed`).
 
 `KumoAppContext.shared` is a tiny `@MainActor` singleton that exposes the live `KumoAppStore` and SwiftUI window-opening actions to the AppDelegate, status item, App Intents, and Services callbacks (none of which sit inside the SwiftUI view tree).
@@ -37,12 +39,25 @@ uses a dedicated `isSwitchingMode` state instead of the global `isLoading` flag
 so the Start / Stop toolbar action does not flash disabled during a mode-only
 change.
 
+Inspect pages keep toolbar search attached to the page container rather than
+only to populated `Table` / `List` branches. A no-match state must not remove
+the search field, because users need the same toolbar control to clear or edit
+the query.
+
 The Overview metric cards are interactive summaries. They use native `Button`
 controls to navigate into the relevant sidebar destinations and expose focused
 context-menu actions such as refresh, proxy toggle, or opening the matching
 settings page.
 
+Overview proxy group menus are intentionally bounded. They provide quick access
+to the first visible proxy choices and route large groups to the full Proxies
+page instead of creating oversized status menus.
+
 The Configure views may begin as small setting surfaces, but user-visible controls must correspond to shared `KumoCoreKit` behavior. Do not add a SwiftUI-only setting that bypasses the runtime builder, state store, or controller facade.
+System-facing configuration forms such as Core runtime settings and System
+Proxy settings should stage edits in local SwiftUI state and commit them through
+explicit Apply actions. This avoids writing partially typed ports, hosts, or
+network service names into the shared controller layer.
 
 ## Liquid Glass Usage
 

--- a/docs/quality/testing-quality.md
+++ b/docs/quality/testing-quality.md
@@ -61,6 +61,9 @@ Prioritize tests that do not mutate real system state:
 - System proxy dry-run prints the expected commands.
 - SwiftUI window opens with Overview selected.
 - Settings opens with Cmd+,.
+- Inspect search fields remain available when a query returns no matches.
+- Core runtime and System Proxy settings only commit after the user applies staged edits.
+- TUN helper uninstall asks for confirmation before removing the service.
 - Menu bar status item exposes start, stop, mode switching, refresh, profiles, proxy groups, and system proxy controls.
 - App updates check the default GitHub Releases feed when no manifest override is set.
 - App update DMG downloads fail closed on SHA-256 mismatch and report a clear error when the current app location is not writable.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep Inspect search fields available in no-match states.
- Stage Core runtime and System Proxy edits behind Apply/Reset controls.
- Add confirmation for service uninstall and improve profile/override import layouts.
- Add keyboard navigation commands and bound Overview proxy quick menus.
- Update UI and QA docs for the new interaction rules.

## Verification
- `swift build` attempted, but the cloud environment does not have `swift` installed (`swift: command not found`).
- `swift test` attempted, but the cloud environment does not have `swift` installed (`swift: command not found`).
- `git diff --check HEAD` passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4600528e-9e75-498d-9be6-c001c5b50813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4600528e-9e75-498d-9be6-c001c5b50813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

